### PR TITLE
Add topster deletion functionality with password check

### DIFF
--- a/src/app/api/topsters/[id]/route.ts
+++ b/src/app/api/topsters/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { connectDB } from '@/libs/api-server/mongoose'
 import { Topster } from '@/models/topster-schema.model'
+import { verifyPassword } from '@/libs/utils/password'
 
 
 export const GET = async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
@@ -10,6 +11,42 @@ export const GET = async (req: NextRequest, { params }: { params: Promise<{ id: 
     }
     await connectDB()
     
-    const topster = await Topster.findById(id).select('-password')
+    const topster = await Topster.findOne({ _id: id, deleted: false }).select('-password')
     return NextResponse.json(topster, { status: 200 }) // 200 OK
+}
+
+export const DELETE = async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params // await 해 줘야 됨
+    if (!id) {
+        return new Response(JSON.stringify({ error: 'Missing topster ID' }), { status: 400 })
+    }
+    await connectDB()
+    
+    let password = ''
+    try {
+        password = req.headers.get('x-delete-topster-password') as string
+    } catch {
+        return new Response(JSON.stringify({ error: 'Password Required' }), { status: 400 })
+    }
+    
+    if (!password) {
+        return new Response(JSON.stringify({ error: 'Password Required' }), { status: 400 })
+    }
+    
+    const topster = await Topster.findById(id).select('+password')
+    if (!topster) {
+        return new Response(JSON.stringify({ error: 'Topster not found' }), { status: 404 })
+    }
+    
+    const isMatch = await verifyPassword(password, topster.password)
+    
+    const adminKey = process.env.ADMIN_KEY || ''
+    if (!isMatch && password.trim() !== adminKey) {
+        return new Response(JSON.stringify({ error: 'Invalid password' }), { status: 401 })
+    }
+    
+    topster.deleted = true
+    await topster.save()
+    
+    return NextResponse.json({ message: 'Topster deleted successfully' }, { status: 200 }) // 200 OK
 }

--- a/src/app/api/topsters/route.ts
+++ b/src/app/api/topsters/route.ts
@@ -12,8 +12,8 @@ export const GET = async (req: NextRequest) => { // 모든 rating 가져오기
     
     await connectDB()
     const query = cursor
-                  ? { createdAt: { $lt: new Date(cursor) } }
-                  : {}
+                  ? { createdAt: { $lt: new Date(cursor) }, deleted: false }
+                  : { deleted: false }
     const topsters = await Topster.find(query)
                                   .select('-password')
                                   .sort({ createdAt: -1 })

--- a/src/app/topsters/[id]/page.tsx
+++ b/src/app/topsters/[id]/page.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import React, { useMemo, useRef } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { useGetTopster } from '@/hooks/use-topster'
 import { isEmpty } from 'lodash'
 import { ResizableGridDefault } from '@/components/resizable-grid/resizeable-grid-default'
 import { useRouter } from 'next/navigation'
 import html2canvas from 'html2canvas'
 import { Button } from '@/components/buttons'
+import { Delete, Pencil } from 'lucide-react'
+import { Dialogs } from '@/components/dialogs'
 
 
 const TopsterDetailPage = ({ params }: { params: Promise<{ id: string }> }) => {
@@ -14,6 +16,8 @@ const TopsterDetailPage = ({ params }: { params: Promise<{ id: string }> }) => {
     const appRouter = useRouter()
     const { data: topster, isLoading } = useGetTopster(id)
     const topsterRef = useRef<HTMLDivElement>(null)
+    
+    const [deleteDialogOpen, setDeleteDialogOpen] = useState<boolean>(false)
     
     const handleSaveAsImage = () => {
         const element = topsterRef.current
@@ -81,19 +85,40 @@ const TopsterDetailPage = ({ params }: { params: Promise<{ id: string }> }) => {
     
     const gridSize = useMemo(() => topster ? topster.size : 0, [topster])
     
+    const deleteComponent = useMemo(() => <Delete className='text-tunelog-secondary w-4 h-4 shrink-0'/>, [])
+    const editComponent = useMemo(() => <Pencil className='text-tunelog-secondary w-4 h-4 shrink-0'/>, [])
+    
     if (isLoading) {
         return <div className='text-white'>Loading...</div>
     }
     
     return (
         <div className='w-full h-full flex flex-col overflow-y-auto hide-sidebar gap-y-10 text-white p-4'>
-            <div className='flex justify-between items-start'>
+            <div className='flex md:flex-row flex-col md:justify-between items-start gap-2'>
                 <div className='flex flex-col gap-y-2.5'>
                     <h1 className='text-36-bold text-[#A4C7C6]'>{topster?.title ?? ''}</h1>
                     <p className='text-14-regular text-[#EFEEE0]'>{`Made By ${topster?.author ?? ''}`}</p>
                     <p className='text-14-regular text-[#EFEEE0]'>{`Created At ${new Date(topster?.createdAt ?? 0).toLocaleDateString() ?? ''}`}</p>
                 </div>
-                <Button.Box text='Save as Image' onClick={handleSaveAsImage}/>
+                <div className='flex overflow-x-auto hide-sidebar gap-x-2'>
+                    <Button.Box
+                        text='Save as Image'
+                        onClick={handleSaveAsImage}
+                    />
+                    <Button.Box
+                        text='Delete'
+                        onClick={() => setDeleteDialogOpen(true)}
+                        leftIcon={deleteComponent}
+                    />
+                    <Button.Box
+                        text='Edit'
+                        onClick={() => {
+                            //TODO. Implement edit functionality
+                        }}
+                        disabled
+                        leftIcon={editComponent}
+                    />
+                </div>
             </div>
             
             <div className='flex md:flex-row flex-col gap-x-8 gap-y-4'>
@@ -128,6 +153,12 @@ const TopsterDetailPage = ({ params }: { params: Promise<{ id: string }> }) => {
                     </div>
                 </div>
             </div>
+            <Dialogs.DeleteObject
+                open={deleteDialogOpen}
+                onCloseAction={() => setDeleteDialogOpen(false)}
+                object={topster}
+                type='topster'
+            />
         </div>
     )
 }

--- a/src/components/dialogs/dialog-delete-object.tsx
+++ b/src/components/dialogs/dialog-delete-object.tsx
@@ -12,6 +12,7 @@ import { Topster } from '@/libs/interfaces/topster.interface'
 import { useDeleteJournal } from '@/hooks/use-journal'
 import { useRouter } from 'next/navigation'
 import { capitalizeFirstLetter } from '@/libs/utils/string'
+import { useDeleteTopster } from '@/hooks/use-topster'
 
 
 export interface DialogDeleteObjectProps {
@@ -32,33 +33,45 @@ export const DialogDeleteObject = ({
     const [password, setPassword] = useState<string>('')
     const { mutateAsync: deleteRating, isPending: isRatingPending } = useDeleteRating()
     const { mutateAsync: deleteJournal, isPending: isJournalPending } = useDeleteJournal()
+    const { mutateAsync: deleteTopster, isPending: isTopsterPending } = useDeleteTopster()
     
-    const isPending = useMemo(() => isRatingPending || isJournalPending, [isRatingPending, isJournalPending])
+    const isPending = useMemo(() => isRatingPending || isJournalPending || isTopsterPending, [isRatingPending, isJournalPending, isTopsterPending])
     
     const handleDelete = useCallback(async () => {
         if (!object || isEmpty(password) || isPending) return
         try {
             let response
-            if (type === 'rating') {
-                response = await deleteRating({
-                    id: object._id,
-                    rating: {
-                        password
-                    }
-                })
-            } else {
-                response = await deleteJournal({
-                    id: object._id,
-                    journal: {
-                        password
-                    }
-                })
+            switch (type) {
+                case 'rating':
+                    response = await deleteRating({
+                        id: object._id,
+                        rating: {
+                            password
+                        }
+                    })
+                    break
+                case 'journal':
+                    response = await deleteJournal({
+                        id: object._id,
+                        journal: {
+                            password
+                        }
+                    })
+                    break
+                case 'topster':
+                    response = await deleteTopster({
+                        id: object._id,
+                        topster: {
+                            password
+                        }
+                    })
+                    break
             }
             if (response) {
                 setPassword('')
                 onCloseAction()
                 toast.success(`${type} deleted successfully.`)
-                if (type === 'journal') {
+                if (type === 'journal' || type === 'topster') {
                     appRouter.back()
                 }
             } else {
@@ -67,7 +80,7 @@ export const DialogDeleteObject = ({
         } catch {
             toast.error(`Failed to delete ${type}. Please check your password and try again.`)
         }
-    }, [object, password, isPending, type, deleteRating, deleteJournal, onCloseAction, appRouter])
+    }, [object, password, isPending, type, deleteRating, deleteJournal, deleteTopster, onCloseAction, appRouter])
     
     if (!object) return null
     return (

--- a/src/hooks/use-topster.ts
+++ b/src/hooks/use-topster.ts
@@ -1,5 +1,5 @@
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { TopsterCreateRequest, TopsterResponse } from '@/libs/dto/topster.dto'
+import { TopsterCreateRequest, TopsterDeleteRequest, TopsterResponse } from '@/libs/dto/topster.dto'
 import ApiTopster from '@/libs/api/api-topster'
 import { DataConnection } from '@/libs/dto/rating.dto'
 
@@ -27,6 +27,16 @@ export const usePostTopster = () => {
         mutationFn: async (topster: TopsterCreateRequest) => await ApiTopster._post_topster(topster),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['topster-all'] })
+        }
+    })
+}
+export const useDeleteTopster = () => {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: async ({ id, topster }: { id: string, topster: TopsterDeleteRequest }) => await ApiTopster._delete_topster(id, topster),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['topster-all'] })
+            queryClient.invalidateQueries({ queryKey: ['topster'] })
         }
     })
 }

--- a/src/libs/api/api-topster.ts
+++ b/src/libs/api/api-topster.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { TopsterCreateRequest, TopsterResponse } from '@/libs/dto/topster.dto'
+import { TopsterCreateRequest, TopsterDeleteRequest, TopsterResponse } from '@/libs/dto/topster.dto'
 import { Topster } from '@/libs/interfaces/topster.interface'
 import { DataConnection } from '@/libs/dto/rating.dto'
 
@@ -37,6 +37,18 @@ const apiTopster = {
         } catch (e) {
             console.error('ApiTopster._post_topster', e)
             return null
+        }
+    },
+    _delete_topster: async (id: string, topster: TopsterDeleteRequest): Promise<boolean> => {
+        try {
+            const response = await axios.delete(`/api/topsters/${id}`, {
+                headers: {
+                    'x-delete-topster-password': topster.password || ''
+                }
+            })
+            return response.status === 200
+        } catch {
+            return false
         }
     }
 }

--- a/src/libs/dto/topster.dto.ts
+++ b/src/libs/dto/topster.dto.ts
@@ -5,4 +5,6 @@ export type TopsterCreateRequest = Pick<ITopster, 'components' | 'title' | 'size
 
 export type TopsterUpdateRequest = Partial<Pick<ITopster, 'components' | 'title' | 'size' | 'showTitles' | 'showTypes'>>
 
+export type TopsterDeleteRequest = { password: string }
+
 export type TopsterResponse = ITopster


### PR DESCRIPTION
Implemented API and frontend logic to allow deleting topsters with password verification. Updated API routes, hooks, DTOs, and UI components to support deletion, including admin override and soft delete. Only non-deleted topsters are now returned in queries.