### PR TITLE
Add reply endpoints and enhance reply model

### DIFF
--- a/src/app/api/journals/[id]/reply/[replyId]/route.ts
+++ b/src/app/api/journals/[id]/reply/[replyId]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectDB } from '@/libs/api-server/mongoose'
+import { findUserByCookie } from '@/libs/utils/password'
+import { IReply } from '@/libs/interfaces/rating.interface'
+import { Journal } from '@/models/journal-schema.model'
+
+
+export const DELETE = async (req: NextRequest, { params }: { params: Promise<{ id: string, replyId: string }> }) => {
+    const { id, replyId } = await params
+    await connectDB()
+    const user = await findUserByCookie()
+    if (!user || !id || !replyId) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const journal = await Journal.findById(id)
+    if (!journal) {
+        return NextResponse.json({ error: 'Journal not found' }, { status: 404 })
+    }
+    if (!journal.replies.some((reply: IReply) => reply._id.toString() === replyId && reply.uid.toString() === user._id.toString())) {
+        return NextResponse.json({ error: 'Reply not found or not owned by user' }, { status: 404 })
+    }
+    journal.replies = journal.replies.filter((reply: IReply) => reply._id.toString() !== replyId)
+    await journal.save()
+    return NextResponse.json('OK', { status: 200 })
+}

--- a/src/app/api/journals/[id]/reply/route.ts
+++ b/src/app/api/journals/[id]/reply/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectDB } from '@/libs/api-server/mongoose'
+import { findUserByCookie } from '@/libs/utils/password'
+import { Journal } from '@/models/journal-schema.model'
+
+
+export const POST = async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params
+    await connectDB()
+    const user = await findUserByCookie()
+    if (!user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const journal = await Journal.findById(id)
+    if (!journal) {
+        return NextResponse.json({ error: 'Journal not found' }, { status: 404 })
+    }
+    const body = await req.json()
+    const { comment, author } = body
+    const newReply = {
+        comment,
+        author: author || '',
+        uid: user._id.toString(),
+        isEdited: false,
+        deleted: false,
+        likedUids: []
+    }
+    journal.replies.push(newReply)
+    await journal.save()
+    const object = journal.toObject()
+    delete object.password
+    return NextResponse.json(object, { status: 201 }) // 201 Created
+}

--- a/src/app/api/ratings/[id]/reply/[replyId]/route.ts
+++ b/src/app/api/ratings/[id]/reply/[replyId]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectDB } from '@/libs/api-server/mongoose'
+import { findUserByCookie } from '@/libs/utils/password'
+import { Rating } from '@/models/rating-schema.model'
+import { IReply } from '@/libs/interfaces/rating.interface'
+
+
+export const DELETE = async (req: NextRequest, { params }: { params: Promise<{ id: string, replyId: string }> }) => {
+    const { id, replyId } = await params
+    await connectDB()
+    const user = await findUserByCookie()
+    if (!user || !id || !replyId) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const rating = await Rating.findById(id)
+    if (!rating) {
+        return NextResponse.json({ error: 'Rating not found' }, { status: 404 })
+    }
+    if (!rating.replies.some((reply: IReply) => reply._id.toString() === replyId && reply.uid.toString() === user._id.toString())) {
+        return NextResponse.json({ error: 'Reply not found or not owned by user' }, { status: 404 })
+    }
+    rating.replies = rating.replies.filter((reply: IReply) => reply._id.toString() !== replyId)
+    await rating.save()
+    return NextResponse.json('OK', { status: 200 })
+}

--- a/src/app/api/ratings/[id]/reply/route.ts
+++ b/src/app/api/ratings/[id]/reply/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectDB } from '@/libs/api-server/mongoose'
+import { findUserByCookie } from '@/libs/utils/password'
+import { Rating } from '@/models/rating-schema.model'
+
+
+export const POST = async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params
+    await connectDB()
+    const user = await findUserByCookie()
+    if (!user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const rating = await Rating.findById(id)
+    if (!rating) {
+        return NextResponse.json({ error: 'Rating not found' }, { status: 404 })
+    }
+    const body = await req.json()
+    const { comment, author } = body
+    const newReply = {
+        comment,
+        author: author || '',
+        uid: user._id.toString(),
+        isEdited: false,
+        deleted: false,
+        likedUids: []
+    }
+    rating.replies.push(newReply)
+    await rating.save()
+    const object = rating.toObject()
+    delete object.password
+    return NextResponse.json(object, { status: 201 }) // 201 Created
+}

--- a/src/app/api/topsters/[id]/reply/[replyId]/route.ts
+++ b/src/app/api/topsters/[id]/reply/[replyId]/route.ts
@@ -1,0 +1,25 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectDB } from '@/libs/api-server/mongoose'
+import { findUserByCookie } from '@/libs/utils/password'
+import { IReply } from '@/libs/interfaces/rating.interface'
+import { Topster } from '@/models/topster-schema.model'
+
+
+export const DELETE = async (req: NextRequest, { params }: { params: Promise<{ id: string, replyId: string }> }) => {
+    const { id, replyId } = await params
+    await connectDB()
+    const user = await findUserByCookie()
+    if (!user || !id || !replyId) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const topster = await Topster.findById(id)
+    if (!topster) {
+        return NextResponse.json({ error: 'Topster not found' }, { status: 404 })
+    }
+    if (!topster.replies.some((reply: IReply) => reply._id.toString() === replyId && reply.uid.toString() === user._id.toString())) {
+        return NextResponse.json({ error: 'Reply not found or not owned by user' }, { status: 404 })
+    }
+    topster.replies = topster.replies.filter((reply: IReply) => reply._id.toString() !== replyId)
+    await topster.save()
+    return NextResponse.json('OK', { status: 200 })
+}

--- a/src/app/api/topsters/[id]/reply/route.ts
+++ b/src/app/api/topsters/[id]/reply/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { connectDB } from '@/libs/api-server/mongoose'
+import { findUserByCookie } from '@/libs/utils/password'
+import { Topster } from '@/models/topster-schema.model'
+
+
+export const POST = async (req: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
+    const { id } = await params
+    await connectDB()
+    const user = await findUserByCookie()
+    if (!user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+    const topster = await Topster.findById(id)
+    if (!topster) {
+        return NextResponse.json({ error: 'Topster not found' }, { status: 404 })
+    }
+    const body = await req.json()
+    const { comment, author } = body
+    const newReply = {
+        comment,
+        author: author || '',
+        uid: user._id.toString(),
+        isEdited: false,
+        deleted: false,
+        likedUids: []
+    }
+    topster.replies.push(newReply)
+    await topster.save()
+    const object = topster.toObject()
+    delete object.password
+    return NextResponse.json(object, { status: 201 }) // 201 Created
+}

--- a/src/libs/interfaces/rating.interface.ts
+++ b/src/libs/interfaces/rating.interface.ts
@@ -9,6 +9,8 @@ export interface IReply {
     updatedAt: Date
     isEdited?: boolean
     deleted?: boolean
+    uid: string
+    likedUids?: string[]
 } // 댓글
 
 export interface IRating {
@@ -37,6 +39,8 @@ export class Reply implements IReply {
     updatedAt: Date
     isEdited?: boolean
     deleted?: boolean
+    uid: string
+    likedUids?: string[]
     
     constructor(reply: IReply) {
         this._id = reply._id
@@ -46,6 +50,8 @@ export class Reply implements IReply {
         this.updatedAt = reply.updatedAt
         this.isEdited = reply.isEdited || false
         this.deleted = reply.deleted || false
+        this.uid = reply.uid || ''
+        this.likedUids = reply.likedUids || []
     }
 }
 

--- a/src/models/rating-schema.model.ts
+++ b/src/models/rating-schema.model.ts
@@ -5,7 +5,9 @@ export const replySchema = new mongoose.Schema({
     comment: { type: String, required: true },
     author: { type: String, required: false, default: '' },
     isEdited: { type: Boolean, default: false },
-    deleted: { type: Boolean, default: false }
+    deleted: { type: Boolean, default: false },
+    uid: { type: String, required: true },
+    likedUids: { type: [String], default: [] }
 }, { timestamps: true })
 
 const ratingSchema = new mongoose.Schema({


### PR DESCRIPTION
This pull request introduces API endpoints for creating and deleting replies on journals, ratings, and topsters, and standardizes the reply data structure across the codebase. The changes ensure that only authenticated users can create or delete their own replies, and that replies are consistently structured and stored in the database.

**API Endpoint Additions**

* Added `POST` endpoints for creating replies to journals, ratings, and topsters, requiring authentication and associating replies with the current user. (`src/app/api/journals/[id]/reply/route.ts` [src/app/api/journals/[id]/reply/route.tsR1-R33](diffhunk://#diff-417f99754449b100421dc51d8d8d37db4736d851e8c0a313c352c555ef26b121R1-R33), `src/app/api/ratings/[id]/reply/route.ts` [src/app/api/ratings/[id]/reply/route.tsR1-R33](diffhunk://#diff-b0a98d850d87d8b913c48a8418f85194d6c735e8ba429aae6a96b32eefa7e735R1-R33), `src/app/api/topsters/[id]/reply/route.ts` [src/app/api/topsters/[id]/reply/route.tsR1-R33](diffhunk://#diff-e39e7d3c007d14d1e2ca1f056af39f07bdc63453cb2bacf13e971d4ef7a50c9eR1-R33))
* Added `DELETE` endpoints for removing replies from journals, ratings, and topsters, ensuring only the reply owner can delete their reply. (`src/app/api/journals/[id]/reply/[replyId]/route.ts` [src/app/api/journals/[id]/reply/[replyId]/route.tsR1-R25](diffhunk://#diff-0edb177140193c7b8d0fd6f836743ca5fdbedf84bcb80ab0ecc9c43622861de2R1-R25), `src/app/api/ratings/[id]/reply/[replyId]/route.ts` [src/app/api/ratings/[id]/reply/[replyId]/route.tsR1-R25](diffhunk://#diff-98c4e0b925b5a0b98f9a6991b66c5b521b914ee6c7539cdc0c75a407dab4a418R1-R25), `src/app/api/topsters/[id]/reply/[replyId]/route.ts` [src/app/api/topsters/[id]/reply/[replyId]/route.tsR1-R25](diffhunk://#diff-2100ad5ea05c515511f55d52473890abc98ccb21708c5305b87c386a30a5c035R1-R25))

**Reply Data Model Updates**

* Updated the `IReply` interface and `Reply` class to include `uid` (user ID of the reply author) and `likedUids` (array of user IDs who liked the reply), ensuring replies are associated with users and can track likes. (`src/libs/interfaces/rating.interface.ts` [[1]](diffhunk://#diff-fca151d8bc8e37ec9fba8109b0c0b9e3eacdf368ff6747b9a9f084c60f1f8303R12-R13) [[2]](diffhunk://#diff-fca151d8bc8e37ec9fba8109b0c0b9e3eacdf368ff6747b9a9f084c60f1f8303R42-R43) [[3]](diffhunk://#diff-fca151d8bc8e37ec9fba8109b0c0b9e3eacdf368ff6747b9a9f084c60f1f8303R53-R54)
* Modified the Mongoose reply schema to require `uid` and add the `likedUids` array, aligning the database structure with the updated interface. (`src/models/rating-schema.model.ts` [src/models/rating-schema.model.tsL8-R10](diffhunk://#diff-1647cbcb39724fce06069e4e512650d66e2c7f849b7f83ffc15084aae56bed57L8-R10))Implemented POST and DELETE API routes for replies on journals, ratings, and topsters. Updated the IReply interface and reply schema to include uid and likedUids fields for better user association and like tracking.