### PR TITLE
repliy 를 일반 api 에서 없애기

### DIFF
--- a/src/app/api/community/route.ts
+++ b/src/app/api/community/route.ts
@@ -54,14 +54,14 @@ export const GET = async (req: NextRequest) => { // 모든 커뮤니티 게시�
         const pipeline: PipelineStage[] = [
             { $match: finalQuery },
             { $addFields: { itemType: 'rating' } },
-            { $project: { password: 0 } },
+            { $project: { password: 0, replies: 0 } },
             {
                 $unionWith: {
                     coll: 'journals',
                     pipeline: [
                         { $match: finalQuery },
                         { $addFields: { itemType: 'journal' } },
-                        { $project: { password: 0 } }
+                        { $project: { password: 0, replies: 0 } }
                     ]
                 }
             },
@@ -71,7 +71,7 @@ export const GET = async (req: NextRequest) => { // 모든 커뮤니티 게시�
                     pipeline: [
                         { $match: finalQuery },
                         { $addFields: { itemType: 'topster' } },
-                        { $project: { password: 0 } }
+                        { $project: { password: 0, replies: 0 } }
                     ]
                 }
             },
@@ -100,7 +100,7 @@ export const GET = async (req: NextRequest) => { // 모든 커뮤니티 게시�
         
         if (model) {
             const data = await model.find(finalQuery)
-                                    .select('-password')
+                                    .select('-password -replies')
                                     .sort({ createdAt: sortDirection })
                                     .limit(limit)
                                     .lean()

--- a/src/app/api/journals/[id]/route.ts
+++ b/src/app/api/journals/[id]/route.ts
@@ -25,7 +25,7 @@ export const GET = async (req: NextRequest, { params }: { params: Promise<{ id: 
             public: true, onlyFollowers: false
         }
     
-    const journal = await Journal.findOne({ _id: id, deleted: false, ...userQuery }).select('-password')
+    const journal = await Journal.findOne({ _id: id, deleted: false, ...userQuery }).select('-password -replies')
     if (!journal) {
         return new Response(JSON.stringify({ error: 'Journal not found' }), { status: 404 })
     }
@@ -106,7 +106,7 @@ export const PATCH = async (req: NextRequest, { params }: { params: Promise<{ id
     
     await journal.save()
     
-    const updateJournal = await Journal.findById(id).select('-password')
+    const updateJournal = await Journal.findById(id).select('-password -replies')
     
     return NextResponse.json(updateJournal, { status: 200 })
 }

--- a/src/app/api/journals/by-spotify-id/route.ts
+++ b/src/app/api/journals/by-spotify-id/route.ts
@@ -41,7 +41,7 @@ export const GET = async (req: NextRequest) => {
         } : baseQuery
     
     const journals = await Journal.find(query)
-                                  .select('-password')
+                                  .select('-password -replies')
                                   .sort({ createdAt: -1 })
                                   .limit(limit)
     

--- a/src/app/api/journals/my/route.ts
+++ b/src/app/api/journals/my/route.ts
@@ -20,7 +20,7 @@ export const GET = async (req: NextRequest) => { // 모든 rating 가져오기
                   ? { createdAt: { $lt: new Date(cursor) }, deleted: false, uid: user._id.toString() }
                   : { deleted: false, uid: user._id.toString() }
     const journals = await Journal.find(query)
-                                  .select('-password')
+                                  .select('-password -replies')
                                   .sort({ createdAt: -1 })
                                   .limit(limit)
     

--- a/src/app/api/journals/route.ts
+++ b/src/app/api/journals/route.ts
@@ -52,7 +52,7 @@ export const GET = async (req: NextRequest) => { // 모든 rating 가져오기
                   ? { createdAt: { $lt: new Date(cursor) }, ...match }
                   : match
     const journals = await Journal.find(query)
-                                  .select('-password')
+                                  .select('-password -replies')
                                   .sort({ createdAt: -1 })
                                   .limit(limit)
     

--- a/src/app/api/journals/user/[uid]/route.ts
+++ b/src/app/api/journals/user/[uid]/route.ts
@@ -19,7 +19,7 @@ export const GET = async (req: NextRequest, { params }: { params: Promise<{ uid:
                   ? { createdAt: { $lt: new Date(cursor) }, ...queryUser }
                   : queryUser
     const journals = await Journal.find(query)
-                                  .select('-password')
+                                  .select('-password -replies')
                                   .sort({ createdAt: -1 })
                                   .limit(limit)
     

--- a/src/app/api/ratings/[id]/route.ts
+++ b/src/app/api/ratings/[id]/route.ts
@@ -40,7 +40,7 @@ export const PATCH = async (req: NextRequest, { params }: { params: Promise<{ id
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
     
-    const rating = await Rating.findById(id)
+    const rating = await Rating.findById(id).select('-password -replies')
     if (!rating) {
         return NextResponse.json({ error: 'Rating not found' }, { status: 404 })
     }

--- a/src/app/api/ratings/by-spotify-id/route.ts
+++ b/src/app/api/ratings/by-spotify-id/route.ts
@@ -33,7 +33,7 @@ export const GET = async (req: NextRequest) => {
                   : { spotifyId, deleted: false, ...userQuery }
     
     const ratings = await Rating.find(query)
-                                .select('-password') // 비밀번호는 제외
+                                .select('-password -replies') // 비밀번호는 제외
                                 .sort({ createdAt: -1 })
                                 .limit(limit)
     

--- a/src/app/api/ratings/my/route.ts
+++ b/src/app/api/ratings/my/route.ts
@@ -26,7 +26,7 @@ export const GET = async (req: NextRequest) => { // 모든 rating 가져오기
                   : { ...queryBase }
     
     const ratings = await Rating.find(query)
-                                .select('-password')
+                                .select('-password -replies')
                                 .sort({ createdAt: sortDirection })
                                 .limit(limit)
     

--- a/src/app/api/ratings/route.ts
+++ b/src/app/api/ratings/route.ts
@@ -22,7 +22,7 @@ export const GET = async (req: NextRequest) => { // 모든 rating 가져오기
                   : { ...queryBase }
     
     const ratings = await Rating.find(query)
-                                .select('-password') // 비밀번호는 제외
+                                .select('-password -replies')
                                 .sort({ createdAt: sortDirection })
                                 .limit(limit)
     

--- a/src/app/api/ratings/user/[uid]/route.ts
+++ b/src/app/api/ratings/user/[uid]/route.ts
@@ -24,7 +24,7 @@ export const GET = async (req: NextRequest, { params }: { params: Promise<{ uid:
                   : { ...queryBase }
     
     const ratings = await Rating.find(query)
-                                .select('-password')
+                                .select('-password -replies')
                                 .sort({ createdAt: sortDirection })
                                 .limit(limit)
     

--- a/src/app/api/topsters/[id]/route.ts
+++ b/src/app/api/topsters/[id]/route.ts
@@ -25,7 +25,7 @@ export const GET = async (req: NextRequest, { params }: { params: Promise<{ id: 
             public: true, onlyFollowers: false
         }
     
-    const topster = await Topster.findOne({ _id: id, deleted: false, ...userQuery }).select('-password')
+    const topster = await Topster.findOne({ _id: id, deleted: false, ...userQuery }).select('-password -replies')
     return NextResponse.json(topster, { status: 200 }) // 200 OK
 }
 
@@ -112,7 +112,7 @@ export const PATCH = async (req: NextRequest, { params }: { params: Promise<{ id
     
     await topster.save()
     
-    const updatedTopster = await Topster.findById(id).select('-password')
+    const updatedTopster = await Topster.findById(id).select('-password -replies')
     
     return NextResponse.json(updatedTopster, { status: 200 })
 }

--- a/src/app/api/topsters/my/route.ts
+++ b/src/app/api/topsters/my/route.ts
@@ -20,7 +20,7 @@ export const GET = async (req: NextRequest) => { // 모든 rating 가져오기
                   ? { createdAt: { $lt: new Date(cursor) }, deleted: false, uid: user._id.toString() }
                   : { deleted: false, uid: user._id.toString() }
     const topsters = await Topster.find(query)
-                                  .select('-password')
+                                  .select('-password -replies')
                                   .sort({ createdAt: -1 })
                                   .limit(limit)
     

--- a/src/app/api/topsters/route.ts
+++ b/src/app/api/topsters/route.ts
@@ -15,7 +15,7 @@ export const GET = async (req: NextRequest) => { // 모든 rating 가져오기
                   ? { createdAt: { $lt: new Date(cursor) }, deleted: false, public: true, onlyFollowers: false }
                   : { deleted: false, public: true, onlyFollowers: false }
     const topsters = await Topster.find(query)
-                                  .select('-password')
+                                  .select('-password -replies')
                                   .sort({ createdAt: -1 })
                                   .limit(limit)
     

--- a/src/app/api/topsters/user/[uid]/route.ts
+++ b/src/app/api/topsters/user/[uid]/route.ts
@@ -19,7 +19,7 @@ export const GET = async (req: NextRequest, { params }: { params: Promise<{ uid:
                   ? { createdAt: { $lt: new Date(cursor) }, ...queryUser }
                   : queryUser
     const topsters = await Topster.find(query)
-                                  .select('-password')
+                                  .select('-password -replies')
                                   .sort({ createdAt: -1 })
                                   .limit(limit)
     


### PR DESCRIPTION
This pull request updates all API endpoints that return `Journal`, `Rating`, and `Topster` documents to exclude the `replies` field from query results, in addition to the existing exclusion of the `password` field. This change ensures that sensitive or unnecessary data (`replies`) is not exposed in API responses across community, user, and item-specific endpoints.

**API response data privacy improvements:**

* Updated all `.select()` calls in `Journal`, `Rating`, and `Topster` queries to exclude both `password` and `replies` fields, ensuring these fields are not returned in GET and PATCH endpoints. ([src/app/api/community/route.tsL103-R103](diffhunk://#diff-33a73635d82e1095a95cf2e30a6aee68fa2b176d73c177e65d854e0be678e27dL103-R103), [src/app/api/journals/[id]/route.tsL28-R28](diffhunk://#diff-ffa8873d0da11d83e4683f280fc91534ee9bca897f51ea78d2d71c6ae5434eafL28-R28), [src/app/api/ratings/[id]/route.tsL43-R43](diffhunk://#diff-52bac5e8c775932b1225e08da511e43051c5c432355f8a500573d474fa3d6519L43-R43), [src/app/api/topsters/[id]/route.tsL28-R28](diffhunk://#diff-893b4fdac61e5e068ba256880ec57309449302fe949845d1de638e041d30d263L28-R28), [src/app/api/topsters/[id]/route.tsL115-R115](diffhunk://#diff-893b4fdac61e5e068ba256880ec57309449302fe949845d1de638e041d30d263L115-R115))
* Modified aggregation pipelines in `community/route.ts` to project out the `replies` field for all collection types (`ratings`, `journals`, `topsters`). [[1]](diffhunk://#diff-33a73635d82e1095a95cf2e30a6aee68fa2b176d73c177e65d854e0be678e27dL57-R64) [[2]](diffhunk://#diff-33a73635d82e1095a95cf2e30a6aee68fa2b176d73c177e65d854e0be678e27dL74-R74)

**Consistency across endpoints:**

* Applied the exclusion of `replies` to user-specific, item-specific, and "my" endpoints for `journals`, `ratings`, and `topsters`, ensuring consistent data privacy throughout the API. ([src/app/api/journals/user/[uid]/route.tsL22-R22](diffhunk://#diff-3b62cd778c04b55dc9a0c7589b172919a817eed2aba335121e31039f3eea0d3fL22-R22), [src/app/api/ratings/user/[uid]/route.tsL27-R27](diffhunk://#diff-f7abd23c7f0896f000d06436bdf927983a6cb49c1b78fbd424c3a5ad84f54adcL27-R27), [src/app/api/topsters/user/[uid]/route.tsL22-R22](diffhunk://#diff-fbdf265b7716f5312f435869eec0bf7e89b07c261d094bdf839b2e512033d4a3L22-R22), [[1]](diffhunk://#diff-333a0ad203f250dad36a3bb64f7e4def0966ab2945edd88d8b7dfaa60f2bb703L23-R23) [[2]](diffhunk://#diff-11033e69d85576cd61628672ae1a3655372cc7f4d3f32df522fcd604b21bc36dL23-R23) [[3]](diffhunk://#diff-38e8bb1014a0137af9d340d964e05e8d8d8619890ababa3338378af43bfe5c75L55-R55) [[4]](diffhunk://#diff-22633988dae75dfdb93a0215cb1c7706ab7e49976a2a901654f7124e25778600L36-R36) [[5]](diffhunk://#diff-132315ad051dee81ca5c06b17b440458937771688478a5a77102d1371de2b82eL29-R29) [[6]](diffhunk://#diff-50fb363b12fc7f23d5a2c550cec4de4df8dbdededae1b817ecd83bc5f3655ed0L25-R25) [[7]](diffhunk://#diff-ce00b2fd9e7a8e66aa479dbd64723a894b09f672be3b3fd5dea0d4596e1ce02bL18-R18) [[8]](diffhunk://#diff-01269e60096bb5ff09b04375d4ec69e966bad12605350c7e3e15b81bc09b14a4L44-R44)

These changes help prevent unnecessary exposure of the `replies` field and improve the security and clarity of API responses.